### PR TITLE
Added engines clause with minimum node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "https://github.com/athombv/devkit.git"
   },
+  "engines" : { 
+    "node" : ">=0.12" 
+  },
   "keywords": [
     "Athom",
     "Homey",


### PR DESCRIPTION
One of the dependencies breaks with Node versions < 0.12. To prevent people from debugging this for quite some time like I did, I added a engines clause that prevents installation in Node 0.10 and lower.